### PR TITLE
Fixed issue #8

### DIFF
--- a/src/projmake-elmm.el
+++ b/src/projmake-elmm.el
@@ -55,9 +55,8 @@
   (projmake-build-state-project build-state))
 
 (defun projmake-elmm/remove-project-list-buffer (build-state)
-  (let* ((project (projmake-elmm/get-project build-state))
-         (buffer (projmake-elmm/get-project-list-buffer project)))
-    (kill-buffer buffer)))
+  (let* ((buffer (projmake-elmm/get-project-list-buffer build-state)))
+    (delete-window (get-buffer-window buffer))))
 
 (defvar-local projmake-elmm/source-build-state nil
   "The currently displaying build state")

--- a/src/projmake-mode.el
+++ b/src/projmake-mode.el
@@ -385,7 +385,7 @@ It's flymake process filter."
   (projmake-banner/show build-state)
   (when (= 0 exitcode)
     (let ((project (projmake-build-state-project build-state)))
-      (projmake-elmm/remove-project-list-buffer project)
+      (projmake-elmm/remove-project-list-buffer build-state)
       (projmake-mode/erase-build-buffer project)))
 
   (projmake-log/info "%s: %d error(s), %d warning(s)"


### PR DESCRIPTION
Turns out that `projmake-elmm/remove-project-list-buffer` was being
passed a `project`, and then trying to pull a project out of it as if it
were a `build-state`. I'm not quite sure how this was working for
anyone.

Also, I closed the window of the error-list buffer, only if there were
no errors.
